### PR TITLE
[fix] Mixed-content alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A containerized node web server to use as a test application for k8s/openshift.
 The page does 4 things (but only one really needed):
   1. Shows the hostname (in the top of the page);
   1. Displays the ENV var `K8SSECRET`;
-  1. Displays a animated lolcat (from [the cat api](http://thecatapi.com/));
+  1. Displays a animated lolcat (from [the cat api](https://thecatapi.com/));
   1. Displays a computer quote.
 
 ### Screenshot

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -7,7 +7,7 @@
           brought to you by <%= process.env.DEPLOYEDBY || 'the Internet' %>!</h1>
         </div><!-- /col-lg-6 -->
         <div class="col-lg-5">
-          <img class="img-responsive" style="margin: 0 auto;" src="http://thecatapi.com/api/images/get?format=src&type=gif" alt="your lolcat">
+          <img class="img-responsive" style="margin: 0 auto;" src="//thecatapi.com/api/images/get?format=src&type=gif" alt="your lolcat">
         </div><!-- /col-lg-6 -->
       </div><!-- /row -->
     </div><!-- /container -->


### PR DESCRIPTION
Use HTTP/S where applicable to reach `thecatapi.com`